### PR TITLE
Fix page_content metadata.

### DIFF
--- a/data_ingestion_to_vectordb/data_ingestion_to_vectordb.py
+++ b/data_ingestion_to_vectordb/data_ingestion_to_vectordb.py
@@ -27,7 +27,7 @@ for t in TENANTS:
     elif t == "tenantb":
         DATAFILE="Amazon_EMR_FAQs.csv"
 
-    loader = CSVLoader(f"./{LOCAL_RAG_DIR}/{DATAFILE}")
+    loader = CSVLoader(f"./{LOCAL_RAG_DIR}/{DATAFILE}", csv_args={"fieldnames": ["question", "answer"]})
     documents_aws = loader.load()
     print(f"documents:loaded:size={len(documents_aws)}")
     


### PR DESCRIPTION
In addition to Document metadata (documented) there is also `page_content` metadata (undocumented) in a LangChain Document. This edit makes that metadata meaningful. Currently the first question and the first answer in each dataset serve as the `page_content` metadata attributes for each document in the corresponding index.